### PR TITLE
Update GNOME runtime version to 49

### DIFF
--- a/io.github.flattool.Ignition.json
+++ b/io.github.flattool.Ignition.json
@@ -1,7 +1,7 @@
 {
 	"id": "io.github.flattool.Ignition",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "48",
+	"runtime-version": "49",
 	"sdk": "org.gnome.Sdk",
 	"sdk-extensions": [
 		"org.freedesktop.Sdk.Extension.node20",


### PR DESCRIPTION
Bump the 'runtime-version' in io.github.flattool.Ignition.json from 48 to 49 to use the latest GNOME platform.