### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/io.github.flattool.Ignition.json
+++ b/io.github.flattool.Ignition.json
@@ -1,7 +1,7 @@
 {
 	"id": "io.github.flattool.Ignition",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "49",
+	"runtime-version": "50",
 	"sdk": "org.gnome.Sdk",
 	"sdk-extensions": [
 		"org.freedesktop.Sdk.Extension.node22",
@@ -25,17 +25,6 @@
 		"--filesystem=/snap:ro",
 		"--filesystem=host-os:ro",
 		"--filesystem=host-etc:ro"
-	],
-	"cleanup": [
-		"/include",
-		"/lib/pkgconfig",
-		"/man",
-		"/share/doc",
-		"/share/gtk-doc",
-		"/share/man",
-		"/share/pkgconfig",
-		"*.la",
-		"*.a"
 	],
 	"modules": [
 		{


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands